### PR TITLE
FIX - Design Adjustments in ramp and quote forms

### DIFF
--- a/src/components/TransactionDetails/index.tsx
+++ b/src/components/TransactionDetails/index.tsx
@@ -23,9 +23,11 @@ export type TransactionDetailProps = PropsWithChildren & {
   showStatusBadge?: boolean;
   transaction?: Transaction;
   quoteRateInverse?: number;
+  quoteRate?: number;
   network?: string;
   title?: string;
   sx?: SxProps;
+  operationType?: string;
 };
 
 const Rate = styled(Typography)(({ theme }) => ({
@@ -38,7 +40,7 @@ const Amount = styled(Typography)(({ theme }) => ({
   fontSize: theme.typography.pxToRem(14),
   fontWeight: 'normal',
   color: theme.palette.ink.i500,
-  textAlign: 'right',
+  textAlign: 'left',
 }));
 
 const GridRow = styled(Grid)(() => ({
@@ -79,6 +81,7 @@ export default function TransactionDetail({
   children,
   transaction,
   quoteRateInverse,
+  quoteRate,
   success = false,
   noContainer = false,
   noArrow = false,
@@ -86,6 +89,7 @@ export default function TransactionDetail({
   network = '',
   title = '',
   sx,
+  operationType,
 }: TransactionDetailProps) {
   const DetailContainer = noContainer ? Box : BoxContainer;
   const networkName = network || transaction?.networkConfig?.name;
@@ -93,6 +97,15 @@ export default function TransactionDetail({
     ? `Deposita ${transaction.baseCurrency} a la cuenta:`
     : `Deposita tu ${transaction?.baseCurrency} a esta dirección en
   ${transaction?.cashinDetails?.network}:`;
+  const rate = operationType === 'deposit' ? quoteRateInverse : quoteRate;
+  const rateText =
+    operationType === 'deposit'
+      ? `1 ${transaction?.quoteCurrency} ≈ ${(
+          <Amount variant="body2">$ {formatNumber(rate)}</Amount>
+        )} ${transaction?.baseCurrency}`
+      : `1 ${transaction?.baseCurrency} ≈ ${(
+          <Amount variant="body2">$ {formatNumber(rate)}</Amount>
+        )} ${transaction?.quoteCurrency}`;
 
   const showBadge = ['CASH_IN_REQUESTED', 'CASH_IN_PROCESSING'].includes(
     transaction?.providerStatus ?? '',
@@ -145,10 +158,9 @@ export default function TransactionDetail({
             $ {formatNumber(transaction?.quoteAmount)}
           </Rate>
         </Grid>
-        {!!quoteRateInverse && (
+        {!!rate && (
           <GridRow xs={12}>
-            <Network variant="body2">Comisión:</Network>
-            <Amount variant="body2">$ {formatNumber(quoteRateInverse)}</Amount>
+            <Network variant="body2">{rateText}</Network>
           </GridRow>
         )}
         {!!networkName && (

--- a/src/components/forms/GetQuoteForm/index.tsx
+++ b/src/components/forms/GetQuoteForm/index.tsx
@@ -119,13 +119,17 @@ export default function GetQuoteForm() {
     if (baseAmount > 0) handleSubmit(debouncedRequest)();
   }, [baseAmount, debouncedRequest, handleSubmit]);
 
-  const onChangeOperationType = (event: ChangeEvent<HTMLSelectElement>) => {
-    const { value } = event.target;
-    const depositCurrencyItms = value === 'deposit' ? sendCurrency : depositCurrency;
-    const sendCurrencyItms = value === 'deposit' ? depositCurrency : sendCurrency;
-    setValue('baseCurrency', depositCurrencyItms[0].value);
-    setValue('quoteCurrency', sendCurrencyItms[0].value);
-  };
+  const onChangeOperationType = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      const { value } = event.target;
+      const depositCurrencyItms = value === 'deposit' ? sendCurrency : depositCurrency;
+      const sendCurrencyItms = value === 'deposit' ? depositCurrency : sendCurrency;
+      setValue('baseCurrency', depositCurrencyItms[0].value);
+      setValue('quoteCurrency', sendCurrencyItms[0].value);
+      if (baseAmount > 0) handleSubmit(debouncedRequest)();
+    },
+    [baseAmount, debouncedRequest, handleSubmit, setValue],
+  );
 
   const onQuantityChange = (event: ChangeEvent<HTMLInputElement>) => {
     event.target.value = event.target.value.replace(/[^0-9.]/g, '');

--- a/src/components/forms/GetQuoteForm/index.tsx
+++ b/src/components/forms/GetQuoteForm/index.tsx
@@ -58,7 +58,10 @@ export default function GetQuoteForm() {
   const depositCurrencyItems = operationType === 'deposit' ? sendCurrency : depositCurrency;
   const sendCurrencyItems = operationType === 'deposit' ? depositCurrency : sendCurrency;
   const operationCurrency = operationType === 'deposit' ? baseCurrency : quoteCurrency;
-
+  const rateText =
+    operationType === 'deposit'
+      ? `1 ${quoteCurrency} ≈ $${formatNumber(data?.quoteRateInverse) ?? 0} ${baseCurrency}`
+      : `1 ${baseCurrency} ≈ $${formatNumber(data?.quoteRate) ?? 0} ${quoteCurrency}`;
   const debouncedRequest = useCallback(
     (formValues: GetQuoteFormValues) =>
       getQuote({
@@ -208,7 +211,6 @@ export default function GetQuoteForm() {
               value={formatNumber(data?.quoteAmount ?? 0)}
               helpText={
                 <>
-                  Tipo de cambio ({baseCurrency}/{quoteCurrency}):&nbsp;
                   {isMutating ? (
                     <CircularProgress
                       size={15}
@@ -216,7 +218,7 @@ export default function GetQuoteForm() {
                       aria-label="submitting"
                     />
                   ) : (
-                    <strong>{data?.quoteRateInverse ?? 0}</strong>
+                    rateText
                   )}
                 </>
               }

--- a/src/components/forms/RampForm/index.tsx
+++ b/src/components/forms/RampForm/index.tsx
@@ -93,8 +93,10 @@ export default function RampForm({ noContainer = false }: Readonly<RampFormProps
           transaction={data || (quote as unknown as Transaction)}
           noContainer={noContainer}
           quoteRateInverse={quote?.quoteRateInverse}
+          quoteRate={quote?.quoteRate}
           network={network ?? ''}
           success={false}
+          operationType={operationType}
         >
           <Grid container spacing={2} sx={{ mx: 0, my: 1 }}>
             {operationType === 'deposit' ? (

--- a/src/layouts/LandingLayout/index.tsx
+++ b/src/layouts/LandingLayout/index.tsx
@@ -101,7 +101,7 @@ export default function LandingLayout({ children }: Readonly<PropsWithChildren>)
                       <div className="text-3">
                         <span style={{ textTransform: 'lowercase', fontSize: '22px' }}>st</span>ETH
                       </div>
-                      <div className="text-4">3.8%</div>
+                      <div className="text-4">3.6%</div>
                     </div>
                     <img
                       src="images/steth-steth-logo.png"
@@ -115,7 +115,7 @@ export default function LandingLayout({ children }: Readonly<PropsWithChildren>)
                   <div className="frame-12743">
                     <div className="frame-12742">
                       <div className="text-3">USDM</div>
-                      <div className="text-4">3.2%</div>
+                      <div className="text-4">5%</div>
                     </div>
                     <img
                       src="images/USDM.png"


### PR DESCRIPTION
Changes some anding page copy on the staking section.

Fixes the rate on the quote form and transaction details, our backend sends an inverted rate for onramps but the correct rate for off ramps so thats why we take this into account.

It also fixes the format of how the rates are shown removing the `Comisión` text and `Tipo de cambio` in favor of `1 {currency} ≈ ${chosen rate} {currency}`

It also fixes a bug that shown an incorrect quote when changing the operation type. so we request from the api on change
<img width="497" alt="Screenshot 2024-02-16 at 15 44 27" src="https://github.com/bandohq/react-bando/assets/5843809/95c235f0-af0e-4d51-9f1e-eb6793144a27">
