### PR TITLE
FIX: Fix input not showing numbers with commas

### DIFF
--- a/src/components/TransactionDetails/RateText.tsx
+++ b/src/components/TransactionDetails/RateText.tsx
@@ -22,14 +22,20 @@ export default function RateText({ operationType, transaction, rate = 0 }: RateT
   if (operationType === 'deposit') {
     return (
       <>
-        1 {transaction?.quoteCurrency} ≈ <Amount variant="body2">${formatNumber(rate)}</Amount>{' '}
+        1 {transaction?.quoteCurrency} ≈{' '}
+        <Amount as="span" variant="body2">
+          ${formatNumber(rate)}
+        </Amount>{' '}
         {transaction?.baseCurrency}
       </>
     );
   }
   return (
     <>
-      1 {transaction?.baseCurrency} ≈ <Amount variant="body2">${formatNumber(rate)}</Amount>{' '}
+      1 {transaction?.baseCurrency} ≈{' '}
+      <Amount as="span" variant="body2">
+        ${formatNumber(rate)}
+      </Amount>{' '}
       {transaction?.quoteCurrency}
     </>
   );

--- a/src/components/forms/GetQuoteForm/index.test.tsx
+++ b/src/components/forms/GetQuoteForm/index.test.tsx
@@ -224,6 +224,7 @@ describe('GetQuoteForm', () => {
 
   it('should handle an error when backend fails', async () => {
     (axios.post as jest.Mock).mockRejectedValue({});
+
     render(<GetQuoteForm />, { wrapper });
 
     const baseAmountInput = screen.getByLabelText('baseAmount') as HTMLInputElement;
@@ -249,6 +250,30 @@ describe('GetQuoteForm', () => {
 
     await waitFor(() => {
       expect(quoteAmountInput.value).toBe('58.47');
+    });
+  });
+
+  it('should cround quote amount to two decimals', async () => {
+    (axios.post as jest.Mock).mockResolvedValue({
+      data: {
+        id: 46,
+        base_currency: 'MXN',
+        base_amount: '500000.00',
+        quote_currency: 'USDC',
+        quote_amount: '29056.901316254385',
+        is_expired: false,
+        expires_at: '2024-01-10T23:06:08.388000Z',
+      },
+    });
+
+    render(<GetQuoteForm />, { wrapper });
+
+    const baseAmountInput = screen.getByLabelText('baseAmount') as HTMLInputElement;
+    const quoteAmountInput = screen.getByLabelText('quoteAmount') as HTMLInputElement;
+    await userEvent.type(baseAmountInput, '500000.00');
+
+    await waitFor(() => {
+      expect(quoteAmountInput.value).toBe('29,056.90');
     });
   });
 });

--- a/src/components/forms/GetQuoteForm/index.tsx
+++ b/src/components/forms/GetQuoteForm/index.tsx
@@ -211,7 +211,7 @@ export default function GetQuoteForm() {
           <Grid md={8} sm={6} xs={7}>
             <Input
               label="Recibes"
-              type="number"
+              type="text"
               name="quoteAmount"
               value={formatNumber(data?.quoteAmount ?? 0)}
               helpText={


### PR DESCRIPTION
- Change disabled quote input from type number to type string, to be able to show number with commas

![Screenshot_2247](https://github.com/bandohq/react-bando/assets/1530383/e1047943-5627-40ed-8ebd-37ebcddaa863)
