### PR TITLE
FIX - ERROR status was also missing

### DIFF
--- a/src/components/TransactionDetails/mapProviderStatus.ts
+++ b/src/components/TransactionDetails/mapProviderStatus.ts
@@ -15,6 +15,7 @@ export default function mapProviderStatus(status: string) {
         color: 'info',
       };
     case 'FAILED':
+    case 'ERROR':
       return {
         text: 'Fallida ',
         color: 'error',


### PR DESCRIPTION
Needed to map `ERROR` status for provider status property. This error code was not in the docs, nevertheless it does show up in unmapped incidents from our provider.