### PR TITLE
task: Handle street data in google autocomplete

### DIFF
--- a/src/components/forms/KycForm/index.tsx
+++ b/src/components/forms/KycForm/index.tsx
@@ -30,8 +30,8 @@ type KYCError = { code: string; error: string };
 
 export default function KycForm() {
   const navigate = useNavigate();
-  const [error, setError] = useState(false);
-  const [KYCError, setKYCError] = useState({ isError: false, message: '' });
+  // const [error, setError] = useState(false);
+  const [kycError, setKycError] = useState({ isError: false, message: '' });
   const [forbiddenError, setForbiddenError] = useState(false);
 
   const { user } = useUser();
@@ -51,6 +51,8 @@ export default function KycForm() {
   });
 
   const onSubmit = async (formValues: KycFormValues) => {
+    setKycError({ isError: false, message: '' });
+
     try {
       await postUserKyc({ ...formValues, email: user?.email as string });
       if (storageQuote.quote?.baseAmount) return navigate('/kyc/ramp', { replace: true });
@@ -65,7 +67,7 @@ export default function KycForm() {
       const errorMsg = errorObject?.response?.data?.error;
       if (errorObject.response?.data.code) {
         const isRfcError = errorMsg?.includes('gov_check_mexico_rfc_error');
-        setKYCError({
+        setKycError({
           isError: true,
           message: isRfcError
             ? 'El RFC proporcionado no es válido'
@@ -73,7 +75,7 @@ export default function KycForm() {
         });
         return;
       }
-      setError(true);
+      setKycError({ isError: true, message: 'Ha ocurrido un error.' });
       return;
     }
   };
@@ -176,14 +178,9 @@ export default function KycForm() {
             {...register('document.number')}
           />
         </Grid>
-        {error && (
+        {kycError.isError && (
           <Grid md={12} sm={12} xs={12} sx={{ mt: 2 }}>
-            <ErrorBox>Ha ocurrido un error.</ErrorBox>
-          </Grid>
-        )}
-        {KYCError.isError && (
-          <Grid md={12} sm={12} xs={12} sx={{ mt: 2 }}>
-            <ErrorBox>{KYCError.message}</ErrorBox>
+            <ErrorBox>{kycError.message}</ErrorBox>
           </Grid>
         )}
         {forbiddenError && (

--- a/src/components/forms/KycForm/index.tsx
+++ b/src/components/forms/KycForm/index.tsx
@@ -30,7 +30,6 @@ type KYCError = { code: string; error: string };
 
 export default function KycForm() {
   const navigate = useNavigate();
-  // const [error, setError] = useState(false);
   const [kycError, setKycError] = useState({ isError: false, message: '' });
   const [forbiddenError, setForbiddenError] = useState(false);
 

--- a/src/components/forms/PlacesAutocomplete/index.tsx
+++ b/src/components/forms/PlacesAutocomplete/index.tsx
@@ -51,6 +51,7 @@ type PlacesAutocompleteProps = MuiInputProps & {
 };
 
 type AddressResults = {
+  name: string;
   address_components: {
     long_name: string;
     short_name: string;
@@ -112,6 +113,9 @@ export default function PlacesAutocomplete({
 
           getDetails({ placeId: opt.place_id }).then((results: AddressResults) => {
             const addressParts = results.address_components;
+
+            const streetName = results.name;
+
             const streetRoute =
               addressParts.find((result) => result.types.includes('route'))?.long_name ?? '';
             const streetNumber =
@@ -123,7 +127,7 @@ export default function PlacesAutocomplete({
               addressParts.find((result) => result.types.includes('postal_code'))?.long_name ?? '';
             const country =
               addressParts.find((result) => result.types.includes('country'))?.short_name ?? '';
-            const street = [streetRoute, streetNumber].join(' ');
+            const street = streetRoute ? [streetRoute, streetNumber].join(' ') : streetName;
 
             setInputValue(opt.description, {
               street,


### PR DESCRIPTION
- When address does not have a street route or number, use the location name for street
- Handle rfc error from the backend to show a better message for the user

### Screenshots
![Screenshot_2349](https://github.com/bandohq/react-bando/assets/1530383/857fca10-5492-44a5-90db-28fc1739b3cb)
![Screenshot_2347](https://github.com/bandohq/react-bando/assets/1530383/c301c7fa-8d80-4d72-ab9b-068ca289cab0)
![Screenshot_2346](https://github.com/bandohq/react-bando/assets/1530383/08e53d12-afb2-41fa-8a53-571fcfe5da43)
![Screenshot_2345](https://github.com/bandohq/react-bando/assets/1530383/9a52100f-c732-4849-941c-83c29e644593)
