### PR TITLE
CHORE: Add a SPEI concepto info box for mxn on ramps

### DIFF
--- a/src/components/Alert/index.test.tsx
+++ b/src/components/Alert/index.test.tsx
@@ -11,7 +11,6 @@ describe('BandoAlert', () => {
         severity="info"
       />,
     );
-    screen.getByLabelText('info-box');
     screen.getByText('This is an outlined info Alert.');
   });
 });

--- a/src/components/Alert/index.test.tsx
+++ b/src/components/Alert/index.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import BandoAlert from '.';
+
+describe('BandoAlert', () => {
+  it('should render BandoInfoAlert', async () => {
+    render(
+        <BandoAlert text="This is an outlined info Alert." aria-label='info-box' variant="outlined" severity="info" />
+    );
+    screen.getByLabelText('info-box');
+    screen.getByText('This is an outlined info Alert.');
+  });
+});

--- a/src/components/Alert/index.test.tsx
+++ b/src/components/Alert/index.test.tsx
@@ -4,7 +4,12 @@ import BandoAlert from '.';
 describe('BandoAlert', () => {
   it('should render BandoInfoAlert', async () => {
     render(
-        <BandoAlert text="This is an outlined info Alert." aria-label='info-box' variant="outlined" severity="info" />
+      <BandoAlert
+        text="This is an outlined info Alert."
+        aria-label="info-box"
+        variant="outlined"
+        severity="info"
+      />,
     );
     screen.getByLabelText('info-box');
     screen.getByText('This is an outlined info Alert.');

--- a/src/components/Alert/index.tsx
+++ b/src/components/Alert/index.tsx
@@ -1,0 +1,27 @@
+import Alert, { AlertProps } from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+import { styled } from '@mui/material/styles';
+
+export type BandoAlertProps = AlertProps & {
+  title?: string,
+  text: string,
+};
+
+const StyledAlert = styled(Alert)<AlertProps>({
+  width: '100%',
+  marginBottom: '10px',
+});
+
+export default function BandoAlert({
+  title,
+  text,
+  severity,
+  variant,
+}: BandoAlertProps) {
+  return (
+    <StyledAlert severity={severity} variant={variant}>
+      {title && (<AlertTitle>{title}</AlertTitle>)}
+      {text}
+    </StyledAlert>
+  );
+}

--- a/src/components/Alert/index.tsx
+++ b/src/components/Alert/index.tsx
@@ -3,8 +3,8 @@ import AlertTitle from '@mui/material/AlertTitle';
 import { styled } from '@mui/material/styles';
 
 export type BandoAlertProps = AlertProps & {
-  title?: string,
-  text: string,
+  title?: string;
+  text: string;
 };
 
 const StyledAlert = styled(Alert)<AlertProps>({
@@ -12,15 +12,10 @@ const StyledAlert = styled(Alert)<AlertProps>({
   marginBottom: '10px',
 });
 
-export default function BandoAlert({
-  title,
-  text,
-  severity,
-  variant,
-}: BandoAlertProps) {
+export default function BandoAlert({ title, text, severity, variant }: BandoAlertProps) {
   return (
     <StyledAlert severity={severity} variant={variant}>
-      {title && (<AlertTitle>{title}</AlertTitle>)}
+      {title && <AlertTitle>{title}</AlertTitle>}
       {text}
     </StyledAlert>
   );

--- a/src/components/Alert/index.tsx
+++ b/src/components/Alert/index.tsx
@@ -8,8 +8,7 @@ export type BandoAlertProps = AlertProps & {
 };
 
 const StyledAlert = styled(Alert)<AlertProps>({
-  width: '100%',
-  marginBottom: '10px',
+  margin: '0 8px',
 });
 
 export default function BandoAlert({ title, text, severity, variant }: BandoAlertProps) {

--- a/src/components/TransactionDetails/index.tsx
+++ b/src/components/TransactionDetails/index.tsx
@@ -248,7 +248,7 @@ export default function TransactionDetail({
                     </DetailText>
                     <TransactionCopyText
                       variant="body2"
-                      sx={{ textAlign: 'right' }}
+                      sx={{ textAlign: 'right', color: 'primary.dark', fontWeight: 700 }}
                       text={transaction?.cashinDetails?.concepto}
                     />
                   </GridRow>

--- a/src/components/TransactionDetails/index.tsx
+++ b/src/components/TransactionDetails/index.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from 'react-i18next';
 
 import RampTitle, { CircularButton as ArrowButton } from '@components/forms/RampForm/RampTitle';
 import RateText from './RateText';
+import BandoAlert from '@components/Alert';
 import CurrencyPill from '@components/forms/RampForm/CurrencyPill';
 import Hr from '@components/Hr';
 import TransactionCopyText, { DetailText } from './TransactionCopyText';
@@ -196,6 +197,9 @@ export default function TransactionDetail({
                 </Typography>
               </GridRow>
             </Grid>
+            {!!transaction?.cashinDetails?.concepto && (
+              <BandoAlert text={t('speiAlert')} title={t('speiAlertTitle')} severity="info" />
+            )}
             <BorderContainer container spacing={2}>
               {!transaction?.cashinDetails?.CLABE ? (
                 <GridRow xs={12} sx={{ gap: 1 }} className="sm-column">

--- a/src/translations/en/landing.ts
+++ b/src/translations/en/landing.ts
@@ -1,7 +1,7 @@
 export default {
   mainTitle: 'Exchange between MXN and crypto in one SPEI',
   subtitle:
-    'With Bando enter and exit the crypto world in seconds with SPE. <separator />. You can deposit or withdraw to your wallet on Ethereum, Arbitrum, Optimism networks, and many more.',
+    'With Bando enter and exit the crypto world in seconds with SPE. <separator />. You can deposit or withdraw to your wallet or exchange to Polygon and soon on Ethereum, Arbitrum, Optimism networks, and many more.',
   section1: {
     title: 'Control your cryptos and explore safely!',
     info: 'Bando is your gateway to crypto as it should be: your keys, your tokens, with low transaction costs and with the DeFi connection you are looking for!',

--- a/src/translations/en/transactionDetail.ts
+++ b/src/translations/en/transactionDetail.ts
@@ -3,9 +3,12 @@ export default {
   bank: 'Bank:',
   name: 'Name:',
   clabe: 'CLABE:',
-  concepto: 'Concept:',
+  concepto: 'Concepto:',
   footer: {
     newTransaction: 'Make another transtacion',
     academy: 'Learn crypto with Bando',
   },
+  speiAlert: 
+    'Make sure the "concepto" field is exactly as shown below. 👇',
+  speiAlertTitle: 'Before you transfer:'
 };

--- a/src/translations/en/transactionDetail.ts
+++ b/src/translations/en/transactionDetail.ts
@@ -8,7 +8,6 @@ export default {
     newTransaction: 'Make another transtacion',
     academy: 'Learn crypto with Bando',
   },
-  speiAlert: 
-    'Make sure the "concepto" field is exactly as shown below. 👇',
-  speiAlertTitle: 'Before you transfer:'
+  speiAlert: 'Make sure the "concepto" field is exactly as shown below. 👇',
+  speiAlertTitle: 'Before you transfer:',
 };

--- a/src/translations/es/landing.ts
+++ b/src/translations/es/landing.ts
@@ -1,7 +1,7 @@
 export default {
   mainTitle: 'Intercambia entre MXN y cripto en un SPEI',
   subtitle:
-    'Con Bando entra y sal del mundo cripto en segundos con SPEI. <separator /> Puedes depositar o retirar a tu wallet en las redes de Ethereum, Arbitrum, Optimism y muchas más.',
+    'Con Bando entra y sal del mundo cripto en segundos con SPEI. <separator /> Puedes depositar o retirar a tu wallet o exchange en la red de Polygon y muy pronto en las redes de Ethereum, Arbitrum, Optimism y muchas más.',
   section1: {
     title: 'Controla tus criptos y explora con seguridad',
     info: 'Bando es tu puerta a cripto como debe ser: tus llaves, tus tokens, con bajos costos de transacción y con la conexión a DeFi que buscas.',

--- a/src/translations/es/transactionDetail.ts
+++ b/src/translations/es/transactionDetail.ts
@@ -8,4 +8,7 @@ export default {
     newTransaction: 'Haz otra transacción',
     academy: 'Aprende cripto con Bando',
   },
+  speiAlert: 
+  'The "concepto" field must be exactly as shown below. Make sure you double check!',
+  speiAlertTitle: 'Antes de transferir:'
 };

--- a/src/translations/es/transactionDetail.ts
+++ b/src/translations/es/transactionDetail.ts
@@ -8,7 +8,6 @@ export default {
     newTransaction: 'Haz otra transacción',
     academy: 'Aprende cripto con Bando',
   },
-  speiAlert: 
-  'The "concepto" field must be exactly as shown below. Make sure you double check!',
-  speiAlertTitle: 'Antes de transferir:'
+  speiAlert: 'Asegurate de que el campo "concepto" sea exactamente como se muestra aquí debajo 👇',
+  speiAlertTitle: 'Antes de transferir:',
 };


### PR DESCRIPTION
Many users have been misleaded and deposited without any regard of the "concepto" field that needs to be exact to match the deposit.

This introduces an alert component and shows and info alert as a reminder of this instruction.
It also highlights the concepto value in bold.

![Screenshot 2024-04-17 at 4 41 18 p m](https://github.com/bandohq/react-bando/assets/5843809/b03a70f2-6847-40c0-ab58-df2357cc878b)
