### PR TITLE
FIX - Missing token logos and chain in details

### DIFF
--- a/src/components/TransactionDetails/index.tsx
+++ b/src/components/TransactionDetails/index.tsx
@@ -107,10 +107,10 @@ export default function TransactionDetail({
 
   const navigate = useNavigate();
   const DetailContainer = noContainer ? Box : BoxContainer;
-  const networkName = network || transaction?.networkConfig?.name;
+  const networkKey = network || transaction?.networkConfig?.key;
   const depositTitle = transaction?.cashinDetails?.CLABE
-    ? `Deposita ${transaction.baseCurrency} a la cuenta:`
-    : `Deposita tu ${transaction?.baseCurrency} a esta dirección en
+    ? `Envía ${transaction.baseCurrency} a la cuenta:`
+    : `Envía tu ${transaction?.baseCurrency} a esta dirección en
   ${transaction?.cashinDetails?.network}:`;
   const rate = operationType === 'deposit' ? quoteRateInverse : quoteRate;
 
@@ -181,14 +181,14 @@ export default function TransactionDetail({
               </Network>
             </GridRow>
           )}
-          {!!networkName && (
+          {!!networkKey && (
             <GridRow xs={12} sx={{ display: 'flex !important' }}>
               <Network variant="body2">Red:</Network>
               <Network variant="body2" sx={{ textAlign: 'right', textTransform: 'capitalize' }}>
-                {networkCurrencyInfo[networkName.toLowerCase()]?.label}{' '}
+                {networkCurrencyInfo[networkKey.toLowerCase()]?.label}{' '}
                 <img
                   alt="Network"
-                  src={networkCurrencyInfo[networkName.toLowerCase()]?.img}
+                  src={networkCurrencyInfo[networkKey.toLowerCase()]?.img}
                   width={18}
                   height={18}
                 />

--- a/src/config/constants/currencies.tsx
+++ b/src/config/constants/currencies.tsx
@@ -1,9 +1,16 @@
-import Currency from '../../assets/Mexico-01.svg';
-import Usdc from '../../assets/image-58_1.png';
-import Usdt from '../../assets/usdt.svg';
-import Polygon from '../../assets/networks/polygon.png';
-import Ethereum from '../../assets/networks/ethereum.png';
 import Mexico from '../../assets/Mexico-01.svg';
+import Currency from '../../assets/Mexico-01.svg';
+import Polygon from '../../assets/networks/polygon.png';
+import Arbitrum from '../../assets/networks/arbitrum.png';
+import Optimism from '../../assets/networks/optimism.png';
+import Ethereum from '../../assets/networks/ethereum.png';
+
+import WETH from '../../assets/chains/weth.png';
+import Usdc from '../../assets/chains/usdc.png';
+import Usdt from '../../assets/chains/usdt.png';
+import MATIC from '../../assets/chains/matic.png';
+import ETH from '../../assets/chains/eth.png';
+import BNB from '../../assets/chains/bnb.png';
 
 import CurrencyImg from '@components/CurrencyImg';
 
@@ -44,6 +51,12 @@ export const currencyImg = {
   USDC: <CurrencyImg src={Usdc} />,
   USDT: <CurrencyImg src={Usdt} />,
   MXN: <CurrencyImg src={Currency} />,
+  ARB: <CurrencyImg src={Arbitrum} />,
+  MATIC: <CurrencyImg src={MATIC} />,
+  WETH: <CurrencyImg src={WETH} />,
+  ETH: <CurrencyImg src={ETH} />,
+  BNB: <CurrencyImg src={BNB} />,
+  OPTIMISM: <CurrencyImg src={Optimism} />,
 };
 
 export const currencyImgPath = {

--- a/src/config/constants/networks.ts
+++ b/src/config/constants/networks.ts
@@ -161,7 +161,7 @@ const networkOptions: NetworkOption = {
     ],
   },
   bsc: {
-    label: 'Binance ',
+    label: 'Binance Smart Chain',
     value: 'bsc',
     img: Binance,
     enabled: false,


### PR DESCRIPTION
<img width="591" alt="Screenshot 2024-05-27 at 1 21 59 a m" src="https://github.com/bandohq/react-bando/assets/5843809/1687abac-725a-4cb2-9466-86791da63380">

Currencypill and transaction details were missing new networks and tokens.
