### PR TITLE
FIX - History rate currency

### DIFF
--- a/src/components/TransactionsTable/TransactionRow.tsx
+++ b/src/components/TransactionsTable/TransactionRow.tsx
@@ -83,6 +83,7 @@ function formatAmounts(amount: number, currency: string) {
 function parseDataForRows(txn: Transaction) {
   return {
     ...txn,
+    quoteCurrency: txn.quoteCurrency.toUpperCase(),
     address: txn?.recipient ?? '',
     networkIcon: networkCurrencyInfo[(txn?.networkConfig?.key ?? '').toLowerCase()]?.img,
     sent: formatAmounts(txn.baseAmount, txn.baseCurrency),
@@ -197,7 +198,7 @@ export default function TransactionRow({
             <>
               <RowTextDetail>
                 <span>{t('table.rate')}</span>
-                {formatNumber(row.quoteRateInverse, 2, 18)} USDC
+                {formatNumber(row.quoteRateInverse, 2, 18)} {row.quoteCurrency}
               </RowTextDetail>
               <RowTextDetail onClick={(e) => e.stopPropagation()}>
                 <span>{t('table.address')}</span>


### PR DESCRIPTION
Fixes hard code on the rate curreny in a txn row:
<img width="834" alt="Screenshot 2024-06-19 at 4 11 29 p m" src="https://github.com/bandohq/react-bando/assets/5843809/65bb4ab2-fae5-4ab0-ad19-a674ac99a35c">
