### PR TITLE
FIX - Don't reset base amount on token switch.

### DIFF
--- a/src/components/TokensWidget/TokensList.tsx
+++ b/src/components/TokensWidget/TokensList.tsx
@@ -98,13 +98,13 @@ export default function TokensList({
                           },
                         }}
                       >
+                        {formatWalletNumber(token?.address ?? '')}
                         <TokenLink
                           href={`${explorerUrl}address/${token?.address}`}
                           target="_blank"
                           onClick={(e) => e.stopPropagation()}
                           rel="noopener noreferrer"
                         >
-                          {formatWalletNumber(token?.address ?? '')}
                           <OpenInNewIcon width={16} height={16} />
                         </TokenLink>
                       </Box>

--- a/src/components/TokensWidget/index.tsx
+++ b/src/components/TokensWidget/index.tsx
@@ -39,6 +39,7 @@ type TokensWidgetProps = {
   onQuantityChange?: () => void;
   resetQuote?: () => void;
   formError?: string;
+  setFormError?: (error: string) => void;
   isLoadingQuote?: boolean;
 };
 
@@ -50,6 +51,7 @@ export default function TokensWidget({
   rateText = '',
   quote,
   formError,
+  setFormError = () => {},
 }: TokensWidgetProps) {
   const { t } = useTranslation('quote');
 
@@ -76,19 +78,19 @@ export default function TokensWidget({
   const onSelectNetwork = (network: Network) => {
     methods.setValue('tokenObj', {});
     if (operationType !== 'withdraw') methods.setValue('quoteCurrency', '');
+    setFormError('');
     methods.setValue('networkObj', network);
-    methods.setValue('baseAmount', 0);
     methods.clearErrors('baseAmount');
   };
 
   const onSelectToken = (token: Token) => {
     methods.setValue('tokenObj', token);
     methods.setValue(isDeposit ? 'quoteCurrency' : 'baseCurrency', token.key ?? token.name);
-    methods.setValue('baseAmount', 0);
-
+    setFormError('');
     resetQuote();
     setOpenSelectDrawer((prev) => !prev);
     methods.clearErrors('baseAmount');
+    onQuantityChange();
   };
 
   const switchOperation = () => {
@@ -294,20 +296,6 @@ export default function TokensWidget({
               </CurrencyAmount>
             </CurrencyTokenButton>
           </Grid>
-
-          {/*<CircularButton
-            role="button"
-            onClick={() => switchOperation()}
-            sx={{
-              position: 'absolute',
-              margin: '0 auto',
-              top: 'calc(50% - 19px)',
-              left: 'calc(50% - 29px)',
-              zIndex: 1000,
-            }}
-          >
-            <img src={UpDownArrow} alt="" width={42} height={42} />
-          </CircularButton>*/}
         </>
       </TokensContainer>
 

--- a/src/components/forms/GetQuoteForm/v2/index.tsx
+++ b/src/components/forms/GetQuoteForm/v2/index.tsx
@@ -165,6 +165,7 @@ export default function GetQuoteFormV2() {
             onQuantityChange={() => debouncedQuoteRequest.current()}
             resetQuote={() => resetQuote()}
             formError={formError}
+            setFormError={setFormError}
             isLoadingQuote={isMutating}
             rateText={
               isMutating ? (


### PR DESCRIPTION
It was configured to reset the baseAmount on token and network switch. Performing the simple change of not doing that and also resetting any errors gives a better user experience.

We also added a requote on token switch to automatically request a new quote as the user experiences a more seamless quote fetching.

Finally, as a drive-by change, we just contained the token explorer link to just the icon. because it was annoying to click on any part on the address and be directed out by accident.