### PR TITLE
FIX - Remove authz headeer from login endpoint.

### DIFF
--- a/src/hooks/useMagicLinkAuth/requests.ts
+++ b/src/hooks/useMagicLinkAuth/requests.ts
@@ -13,8 +13,10 @@ export const postAuthentication: PostAuthenticationRequest = (
   endpoint,
   { arg: { username, password } },
 ) =>
-  axios.post(endpoint, { username, password }).then(({ data }) => ({
-    refresh: data.refresh,
-    token: data.token,
-    kycLevel: data.kyc_level,
-  }));
+  axios
+    .post(endpoint, { username, password }, { headers: { Authorization: '' } })
+    .then(({ data }) => ({
+      refresh: data.refresh,
+      token: data.token,
+      kycLevel: data.kyc_level,
+    }));


### PR DESCRIPTION
We should also remove the `Authorization` header from the login api request. To remove the possibility of 401 errors on that endpoint being sent with invalid jwt tokens.