### PR TITLE
render payment reference if available in transaction history

### DIFF
--- a/src/components/TransactionsTable/TransactionRow.tsx
+++ b/src/components/TransactionsTable/TransactionRow.tsx
@@ -21,6 +21,7 @@ import { StyledTableCell, StyledTableRow, RowTextDetail, TableRowDetail } from '
 
 import { OperationType, Transaction } from '@hooks/useTransaction/requests';
 import formatWalletNumber from '@helpers/formatWalletNumber';
+import translations from "@translations/index.ts";
 
 const ArrowCircleIcon = styled(ArrowCircleIconBase)(({ theme }) => ({
   width: 36,
@@ -110,6 +111,14 @@ export type TransactionRowProps = {
   selectedRow: string;
   onRowClick: (rowId: string) => void;
 };
+
+function PaymentReference({transaction: Transaction}) {
+  const { t } = useTranslation('transactions');
+  if (transaction.cashinDetails?.concepto) {
+    return <RowTextDetail><span>{t('table.reference')}</span>transaction.cashinDetails?.concepto</RowTextDetail>;
+  }
+  return (null);
+}
 
 export default function TransactionRow({
   txn,
@@ -231,12 +240,7 @@ export default function TransactionRow({
                   </>
                 </Box>
               </RowTextDetail>
-              if ({row.payment_reference}) {
-                <RowTextDetail>
-                  <span>{t('table.reference')}</span>
-                  {row.payment_reference}
-                </RowTextDetail>
-              }
+              <PaymentReference transaction={txn}></PaymentReference>
             </>
           </Box>
         </StyledTableCell>

--- a/src/components/TransactionsTable/TransactionRow.tsx
+++ b/src/components/TransactionsTable/TransactionRow.tsx
@@ -230,6 +230,10 @@ export default function TransactionRow({
                   </>
                 </Box>
               </RowTextDetail>
+              <RowTextDetail>
+                <span>{t('table.rate')}</span>
+                {formatNumber(row.quoteRateInverse, 2, 18)} {row.quoteCurrency}
+              </RowTextDetail>
             </>
           </Box>
         </StyledTableCell>

--- a/src/components/TransactionsTable/TransactionRow.tsx
+++ b/src/components/TransactionsTable/TransactionRow.tsx
@@ -120,7 +120,9 @@ export type TransactionPaymentReference = {
 
 function PaymentReference({txn}: TransactionPaymentReference) {
   const { t } = useTranslation('transactions');
-    return {!!txn.cashinDetails?.concepto && (<RowTextDetail><span>{t('table.reference')}</span>{txn.cashinDetails?.concepto}</RowTextDetail>)}
+  const paymentReference = txn.cashinDetails?.concepto;
+
+  return !!paymentReference && (<RowTextDetail><span>{t('table.reference')}</span>{paymentReference}</RowTextDetail>);
 }
 
 export default function TransactionRow({

--- a/src/components/TransactionsTable/TransactionRow.tsx
+++ b/src/components/TransactionsTable/TransactionRow.tsx
@@ -120,10 +120,7 @@ export type TransactionPaymentReference = {
 
 function PaymentReference({txn}: TransactionPaymentReference) {
   const { t } = useTranslation('transactions');
-  if (txn.cashinDetails?.concepto) {
-    return <RowTextDetail><span>{t('table.reference')}</span>{txn.cashinDetails?.concepto}</RowTextDetail>;
-  }
-  return (null);
+    return {!!txn.cashinDetails?.concepto && (<RowTextDetail><span>{t('table.reference')}</span>{txn.cashinDetails?.concepto}</RowTextDetail>)}
 }
 
 export default function TransactionRow({

--- a/src/components/TransactionsTable/TransactionRow.tsx
+++ b/src/components/TransactionsTable/TransactionRow.tsx
@@ -19,7 +19,12 @@ import ArrowDown from '../../assets/ArrowDown.svg';
 import CopyImg from '../../assets/CopyToClipboard.svg';
 import { StyledTableCell, StyledTableRow, RowTextDetail, TableRowDetail } from './TableComponents';
 
-import { OperationType, Transaction } from '@hooks/useTransaction/requests';
+import {
+  DepositCashinDetailsArgs,
+  OperationType,
+  Transaction,
+  WithDrawCashinDetailsArgs
+} from '@hooks/useTransaction/requests';
 import formatWalletNumber from '@helpers/formatWalletNumber';
 import translations from "@translations/index.ts";
 
@@ -112,9 +117,9 @@ export type TransactionRowProps = {
   onRowClick: (rowId: string) => void;
 };
 
-function PaymentReference({transaction: Transaction}) {
+function PaymentReference({concepto}: WithDrawCashinDetailsArgs | DepositCashinDetailsArgs) {
   const { t } = useTranslation('transactions');
-  if (transaction.cashinDetails?.concepto) {
+  if (concepto) {
     return <RowTextDetail><span>{t('table.reference')}</span>transaction.cashinDetails?.concepto</RowTextDetail>;
   }
   return (null);
@@ -240,7 +245,7 @@ export default function TransactionRow({
                   </>
                 </Box>
               </RowTextDetail>
-              <PaymentReference transaction={txn}></PaymentReference>
+              <PaymentReference concepto={txn.cashinDetails?.concepto}></PaymentReference>
             </>
           </Box>
         </StyledTableCell>

--- a/src/components/TransactionsTable/TransactionRow.tsx
+++ b/src/components/TransactionsTable/TransactionRow.tsx
@@ -231,10 +231,12 @@ export default function TransactionRow({
                   </>
                 </Box>
               </RowTextDetail>
-              <RowTextDetail>
-                <span>{t('table.reference')}</span>
-                {row.payment_reference}
-              </RowTextDetail>
+              if ({row.payment_reference}) {
+                <RowTextDetail>
+                  <span>{t('table.reference')}</span>
+                  {row.payment_reference}
+                </RowTextDetail>
+              }
             </>
           </Box>
         </StyledTableCell>

--- a/src/components/TransactionsTable/TransactionRow.tsx
+++ b/src/components/TransactionsTable/TransactionRow.tsx
@@ -114,10 +114,14 @@ export type TransactionRowProps = {
   onRowClick: (rowId: string) => void;
 };
 
-function PaymentReference({cashinDetails?}: Transaction) {
+export type TransactionPaymentReference = {
+  txn: Transaction;
+};
+
+function PaymentReference({txn}: TransactionPaymentReference) {
   const { t } = useTranslation('transactions');
-  if (cashinDetails?.concepto) {
-    return <RowTextDetail><span>{t('table.reference')}</span>{cashinDetails.concepto}</RowTextDetail>;
+  if (txn.cashinDetails?.concepto) {
+    return <RowTextDetail><span>{t('table.reference')}</span>{txn.cashinDetails?.concepto}</RowTextDetail>;
   }
   return (null);
 }
@@ -242,7 +246,7 @@ export default function TransactionRow({
                   </>
                 </Box>
               </RowTextDetail>
-              <PaymentReference cashinDetails={txn.cashinDetails}></PaymentReference>
+              <PaymentReference txn={txn}></PaymentReference>
             </>
           </Box>
         </StyledTableCell>

--- a/src/components/TransactionsTable/TransactionRow.tsx
+++ b/src/components/TransactionsTable/TransactionRow.tsx
@@ -117,9 +117,9 @@ export type TransactionRowProps = {
   onRowClick: (rowId: string) => void;
 };
 
-function PaymentReference({concepto}: WithDrawCashinDetailsArgs | DepositCashinDetailsArgs) {
+function PaymentReference(transaction: Transaction) {
   const { t } = useTranslation('transactions');
-  if (concepto) {
+  if (transaction.cashinDetails?.concepto) {
     return <RowTextDetail><span>{t('table.reference')}</span>transaction.cashinDetails?.concepto</RowTextDetail>;
   }
   return (null);
@@ -245,7 +245,7 @@ export default function TransactionRow({
                   </>
                 </Box>
               </RowTextDetail>
-              <PaymentReference concepto={txn.cashinDetails?.concepto}></PaymentReference>
+              <PaymentReference {txn}></PaymentReference>
             </>
           </Box>
         </StyledTableCell>

--- a/src/components/TransactionsTable/TransactionRow.tsx
+++ b/src/components/TransactionsTable/TransactionRow.tsx
@@ -117,10 +117,10 @@ export type TransactionRowProps = {
   onRowClick: (rowId: string) => void;
 };
 
-function PaymentReference(transaction: Transaction) {
+function PaymentReference({cashinDetails}: Transaction) {
   const { t } = useTranslation('transactions');
-  if (transaction.cashinDetails?.concepto) {
-    return <RowTextDetail><span>{t('table.reference')}</span>transaction.cashinDetails?.concepto</RowTextDetail>;
+  if (cashinDetails?.concepto) {
+    return <RowTextDetail><span>{t('table.reference')}</span>{cashinDetails.concepto}</RowTextDetail>;
   }
   return (null);
 }
@@ -245,7 +245,7 @@ export default function TransactionRow({
                   </>
                 </Box>
               </RowTextDetail>
-              <PaymentReference transaction={txn}></PaymentReference>
+              <PaymentReference cashinDetails={txn.cashinDetails}></PaymentReference>
             </>
           </Box>
         </StyledTableCell>

--- a/src/components/TransactionsTable/TransactionRow.tsx
+++ b/src/components/TransactionsTable/TransactionRow.tsx
@@ -90,6 +90,7 @@ function parseDataForRows(txn: Transaction) {
     networkIcon: txn?.networkConfig?.imageUrl,
     sent: formatAmounts(txn.baseAmount, txn.baseCurrency),
     received: formatAmounts(txn.quoteAmount, txn.quoteCurrency),
+    payment_reference: txn.cashinDetails?.concepto,
     ...(isDeposit
       ? {
           sentIcon: currencyImgPath[txn.baseCurrency as unknown as keyof typeof currencyImgPath],
@@ -232,7 +233,7 @@ export default function TransactionRow({
               </RowTextDetail>
               <RowTextDetail>
                 <span>{t('table.rate')}</span>
-                {formatNumber(row.quoteRateInverse, 2, 18)} {row.quoteCurrency}
+                {row.payment_reference}
               </RowTextDetail>
             </>
           </Box>

--- a/src/components/TransactionsTable/TransactionRow.tsx
+++ b/src/components/TransactionsTable/TransactionRow.tsx
@@ -245,7 +245,7 @@ export default function TransactionRow({
                   </>
                 </Box>
               </RowTextDetail>
-              <PaymentReference {txn}></PaymentReference>
+              <PaymentReference transaction={txn}></PaymentReference>
             </>
           </Box>
         </StyledTableCell>

--- a/src/components/TransactionsTable/TransactionRow.tsx
+++ b/src/components/TransactionsTable/TransactionRow.tsx
@@ -20,13 +20,10 @@ import CopyImg from '../../assets/CopyToClipboard.svg';
 import { StyledTableCell, StyledTableRow, RowTextDetail, TableRowDetail } from './TableComponents';
 
 import {
-  DepositCashinDetailsArgs,
   OperationType,
-  Transaction,
-  WithDrawCashinDetailsArgs
+  Transaction
 } from '@hooks/useTransaction/requests';
 import formatWalletNumber from '@helpers/formatWalletNumber';
-import translations from "@translations/index.ts";
 
 const ArrowCircleIcon = styled(ArrowCircleIconBase)(({ theme }) => ({
   width: 36,
@@ -117,7 +114,7 @@ export type TransactionRowProps = {
   onRowClick: (rowId: string) => void;
 };
 
-function PaymentReference({cashinDetails}: Transaction) {
+function PaymentReference({cashinDetails?}: Transaction) {
   const { t } = useTranslation('transactions');
   if (cashinDetails?.concepto) {
     return <RowTextDetail><span>{t('table.reference')}</span>{cashinDetails.concepto}</RowTextDetail>;

--- a/src/components/TransactionsTable/TransactionRow.tsx
+++ b/src/components/TransactionsTable/TransactionRow.tsx
@@ -232,7 +232,7 @@ export default function TransactionRow({
                 </Box>
               </RowTextDetail>
               <RowTextDetail>
-                <span>{t('table.rate')}</span>
+                <span>{t('table.reference')}</span>
                 {row.payment_reference}
               </RowTextDetail>
             </>

--- a/src/translations/en/transactions.ts
+++ b/src/translations/en/transactions.ts
@@ -8,5 +8,6 @@ export default {
     noFee: 'N/A',
     address: 'Destination account',
     copied: 'Copied. 🫡',
+    reference: 'Payment Reference',
   },
 };

--- a/src/translations/es/transactions.ts
+++ b/src/translations/es/transactions.ts
@@ -8,5 +8,6 @@ export default {
     noFee: 'N/A',
     address: 'Cuenta Destino',
     copied: 'Copiado. 🫡',
+    reference: 'Concepto',
   },
 };


### PR DESCRIPTION
This PR renders the `payment reference (concepto)` if available

## Payment reference is available
![image](https://github.com/user-attachments/assets/e0adace3-71e5-4bec-9f42-8b2978addadf)


## Payment reference is NOT available
![image](https://github.com/user-attachments/assets/d3f0e307-0c44-4aa6-a092-876beda4e71d)


closes #183 