### PR TITLE
Fix typo in footer in spanish

### DIFF
--- a/src/translations/es/footer.ts
+++ b/src/translations/es/footer.ts
@@ -3,7 +3,7 @@ export default {
   productTitle: 'Producto',
   companyTitle: 'Nosotros',
   followUs: 'Síguenos',
-  productFAQ: 'Pregunas Freciuentes',
+  productFAQ: 'Preguntas Frecuentes',
   academyLink: 'Bando Academy',
   statusLink: 'Status',
   terms: 'Términos y Condiciones',


### PR DESCRIPTION
Fixing a small typo in the spanish version of the footer: 

Fixed line is now:
`productFAQ: 'Preguntas Frecuentes'`